### PR TITLE
DCAT-2: Fix the usage score order

### DIFF
--- a/src/ts/component/SearchResultsList/SearchResultsList.tsx
+++ b/src/ts/component/SearchResultsList/SearchResultsList.tsx
@@ -93,13 +93,15 @@ export const SearchResultsList: React.FC<SearchResultsListProps> = ({
 
   const rows = [10, 20, 50, 100]
 
+  const descUsageScore = '-usage_score'
+
   const sortKeys: SortKey[] = [
     {
       key: 'relevance',
       value: 'Relevance'
     },
     {
-      key: 'usage_score',
+      key: descUsageScore,
       value: 'Usage'
     },
     {
@@ -255,7 +257,7 @@ export const SearchResultsList: React.FC<SearchResultsListProps> = ({
             <Dropdown className="search-result-sort__dropdown">
               <Dropdown.Toggle variant="none">
                 <span className="search-result-sort__label">SORT:</span>
-                <span className="search-result-sort__value">{currentSortKey === 'usage_score' ? 'usage' : currentSortKey }</span>
+                <span className="search-result-sort__value">{currentSortKey === descUsageScore ? 'usage' : currentSortKey }</span>
                 <svg className="search-result-sort__svg-icon" width="10" height="10" viewBox="0 0 8 6" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path fillRule="evenodd" clipRule="evenodd" d="M4 3.855L7.233.6 8 1.372 4 5.4 0 1.372.767.6 4 3.855z" fill="black" />
                 </svg>

--- a/src/ts/component/SearchResultsList/__tests__/SearchResultList.test.tsx
+++ b/src/ts/component/SearchResultsList/__tests__/SearchResultList.test.tsx
@@ -266,7 +266,7 @@ describe('SearchResultList', () => {
 
   describe('Sort key', () => {
     describe('when selecting a sort key', () => {
-      test('calls setQuerySort with usage_score', async () => {
+      test('calls setQuerySort with -usage_score', async () => {
         const { props, user } = setup()
 
         await waitFor(async () => {
@@ -275,7 +275,7 @@ describe('SearchResultList', () => {
         })
 
         expect(props.setQuerySort).toHaveBeenCalledTimes(1)
-        expect(props.setQuerySort).toHaveBeenCalledWith('usage_score')
+        expect(props.setQuerySort).toHaveBeenCalledWith('-usage_score')
       })
 
       test('calls setQuerySort with start_data', async () => {

--- a/src/ts/pages/DataCatalog/__tests__/DataCatalog.test.tsx
+++ b/src/ts/pages/DataCatalog/__tests__/DataCatalog.test.tsx
@@ -416,8 +416,8 @@ describe('DataCatalog', () => {
 
       // Click the Next button
       await waitFor(async () => {
-        await user.click(screen.getByRole('button', { name: 'Next' }))
-      })
+        await user.click(await screen.findByRole('button', { name: 'Next' }))
+      }, { timeout: 5000 })
 
       const pagination = await screen.findByRole('list', { name: /pagination/i })
       const pageItems = within(pagination).getAllByRole('listitem')
@@ -462,7 +462,7 @@ describe('DataCatalog', () => {
 
       expect(await screen.findByText('Found collection 1')).toBeTruthy()
 
-      setupMockResponse('page_num=1&sort_key=usage_score')
+      setupMockResponse('page_num=1&sort_key=-usage_score')
 
       await waitFor(async () => {
         await user.click(screen.getByRole('button', { name: /SORT:/ }))
@@ -477,7 +477,7 @@ describe('DataCatalog', () => {
 
   describe('when loading a URL containing a sort_key', () => {
     test('loads the page, using and displaying the appropriate sort key', async () => {
-      const params = 'sort_key=usage_score'
+      const params = 'sort_key=-usage_score'
 
       setupMockResponse(params, 1, 1, 'Found ')
 


### PR DESCRIPTION
# Overview

### What is the feature?
Users expect that the usage sort method return the `most` utilized collection first. This is how results are sort on Earthdata Search. We should ensure there are aligned 

### What is the Solution?

Updated usage sort parameter to sort by most utilized first per 

### What areas of the application does this impact?

Sorting on the main data catalog page

# Testing

### Reproduction steps

- **Environment for testing:*Prod*
- **Collection to test with:*Any*

1. On the search interface use the `lp daac` query parameter to search for lpdaac collections
2. Ensure that when sorting by `Usage` that our results match those we'd expect from CMR/Earthdata search
3. Ensure that navigating to http://localhost:5173/?keyword=lp%20daac&sort_key=-usage_score directly parses that url-parameter and sorts this the same way

### Attachments

![image](https://github.com/user-attachments/assets/160e8cdd-961b-4417-afba-3ee845aef371)

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
