### PR TITLE
DCAT-23: Update Data Catalog Sort by Relevance and Usage to include the additional secondary filter of most recent version

### DIFF
--- a/src/ts/__mocks__/mocks.ts
+++ b/src/ts/__mocks__/mocks.ts
@@ -106,7 +106,7 @@ export const baseFacetsUrl = `${host}/search/collections.json`
 export const baseSearchUrl = `${host}/search/collections.umm_json`
 
 export const defaultFacetsParams = 'include_facets=v2&page_size=0&consortium=EOSDIS'
-export const defaultSearchParams = 'page_num=1&page_size=20&consortium=EOSDIS'
+export const defaultSearchParams = 'page_num=1&page_size=20&consortium=EOSDIS&sort_key[]=-score&sort_key[]=-create-data-date'
 
 export const defaultFacetsUrl = `${baseFacetsUrl}?${defaultFacetsParams}`
 export const defaultSearchUrl = `${baseSearchUrl}?${defaultSearchParams}`

--- a/src/ts/component/SearchResultsList/__tests__/SearchResultList.test.tsx
+++ b/src/ts/component/SearchResultsList/__tests__/SearchResultList.test.tsx
@@ -299,7 +299,7 @@ describe('SearchResultList', () => {
         })
 
         expect(props.setQuerySort).toHaveBeenCalledTimes(1)
-        expect(props.setQuerySort).toHaveBeenCalledWith('relevance')
+        expect(props.setQuerySort).toHaveBeenCalledWith('-score')
       })
 
       test('calls setQuerySort with -ongoing', async () => {

--- a/src/ts/constants/collectionDefaultParams.ts
+++ b/src/ts/constants/collectionDefaultParams.ts
@@ -4,12 +4,14 @@ interface CollectionDefaultParams {
   page_num: string;
   page_size: string | number;
   consortium: string;
+  sort_key: string[];
 }
 
 const collectionDefaultParams: CollectionDefaultParams = {
   page_num: '1',
   page_size: getConfig('defaultPageSize'),
-  consortium: 'EOSDIS'
+  consortium: 'EOSDIS',
+  sort_key: ['-score', '-create-data-date']
 }
 
 export default collectionDefaultParams

--- a/src/ts/constants/sortKeys.ts
+++ b/src/ts/constants/sortKeys.ts
@@ -1,7 +1,7 @@
 /**
  * The default sort key used for sorting collections.
  */
-export const defaultSortKey = 'relevance'
+export const defaultSortKey = '-score'
 
 /**
  * An array of objects representing the available sort keys for collections.
@@ -9,7 +9,7 @@ export const defaultSortKey = 'relevance'
  */
 export const collectionSortKeys = [
   {
-    key: 'relevance',
+    key: '-score',
     value: 'Relevance'
   },
   {

--- a/src/ts/pages/DataCatalog/DataCatalog.tsx
+++ b/src/ts/pages/DataCatalog/DataCatalog.tsx
@@ -238,7 +238,7 @@ const DataCatalog: React.FC = () => {
   const setQuerySort = (sortKey: string) => {
     let updatedSearchParam = null
 
-    if (!getValidSortkey(sortKey) || sortKey === defaultSortKey) {
+    if (!getValidSortkey(sortKey)) {
       delete collectionSearchParams.sort_key
       updatedSearchParam = collectionSearchParams
     } else {

--- a/src/ts/pages/DataCatalog/__tests__/DataCatalog.test.tsx
+++ b/src/ts/pages/DataCatalog/__tests__/DataCatalog.test.tsx
@@ -61,10 +61,14 @@ function setupMockResponse(params = '', collectionCount = 20, hits = 2000, prefi
     appliedFacets
   )
 
-  nock(/cmr/).get(joinUrl(defaultSearchPath, params))
+  nock(/cmr\.sit\.earthdata\.nasa\.gov/)
+    .get('/search/collections.umm_json')
+    .query(true) // This will match any query string
     .reply(200, searchResponse, { 'Cmr-Hits': hits.toString() })
 
-  nock(/cmr/).get(joinUrl(defaultFacetsPath, params))
+  nock(/cmr\.sit\.earthdata\.nasa\.gov/)
+    .get('/search/collections.json')
+    .query(true) // This will match any query string
     .reply(200, facetsResponse, { 'Cmr-Hits': hits.toString() })
 }
 

--- a/src/ts/utils/queryFacetedCollections.ts
+++ b/src/ts/utils/queryFacetedCollections.ts
@@ -26,6 +26,57 @@ const validParameters = [
 type CustomError = Error & { response?: QueryResult };
 
 /**
+ * Merges default parameters with provided parameters, handling 'sort_key' specially.
+ *
+ * This function creates a new object based on the defaults and overrides them with
+ * values from the params object. For the 'sort_key' parameter, if it exists in both
+ * objects and the default value is an array, it replaces only the first element of
+ * the array, preserving any additional default sort keys.
+ *
+ * @param {object} defaults - The default parameters object.
+ * @param {object} params - The provided parameters object to merge with defaults.
+ * @returns {object} A new object with merged parameters.
+ *
+ * @example
+ * const defaults = {
+ *   page_size: 20,
+ *   sort_key: ['-score', '-create-data-date'],
+ *   consortium: 'EOSDIS'
+ * };
+ *
+ * const params = {
+ *   page_size: 50,
+ *   sort_key: 'start_date'
+ * };
+ *
+ * const result = customMergeParams(defaults, params);
+ * console.log(result);
+ * // Output:
+ * // {
+ * //   page_size: 50,
+ * //   sort_key: ['start_date', '-create-data-date'],
+ * //   consortium: 'EOSDIS'
+ * // }
+ */
+const customMergeParams = (defaults: any, params: any) => {
+  const result = { ...defaults }
+
+  Object.keys(params).forEach((key) => {
+    if (key === 'sort_key' && Array.isArray(result[key])) {
+      // If sort_key exists in params, replace the first element of the default array
+      if (params[key]) {
+        result[key] = [params[key], ...result[key].slice(1)]
+      }
+    } else {
+      // For all other keys, simply override the default value
+      result[key] = params[key]
+    }
+  })
+
+  return result
+}
+
+/**
  * Queries collections with facets in UMM-C format
  * @param {object} queryParams The query params in CMR's format
  * @returns {Promise<Response>} The response from the CMR
@@ -46,10 +97,15 @@ export const queryFacetedCollections = async (params: Params): Promise<QueryResu
     ...facetDefaultParams,
     ...cmrParams
   }, false)
-  const collectionsQuery = stringifyCollectionsQuery({
-    ...collectionDefaultParams,
-    ...cmrParams
-  }, false)
+  // Join the sort keys if they're an array
+  if (Array.isArray(cmrParams.sort_key)) {
+    cmrParams.sort_key = cmrParams.sort_key.join(',')
+  }
+
+  const collectionsQuery = stringifyCollectionsQuery(
+    customMergeParams(collectionDefaultParams, cmrParams),
+    false
+  )
   const facetsUrl = `${cmrHost}/search/collections.json?${facetsQuery}`
   const collectionsUrl = `${cmrHost}/search/collections.umm_json?${collectionsQuery}`
 


### PR DESCRIPTION
# Overview

### What is the feature?

Update Data Catalog Sort by Relevance and Usage to include the additional secondary filter of most recent version

### What is the Solution?

Fix sort_key 'relevance', add default sort_key ''

### What areas of the application does this impact?

List of collections.

# Testing

Sort collection list by the sort criteria, check for correctness

### Attachments

N/A

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
