### PR TITLE
DCAT-20: replace 'ongoing' with 'to Present'

### DIFF
--- a/src/ts/component/AppliedFilters/AppliedFilters.tsx
+++ b/src/ts/component/AppliedFilters/AppliedFilters.tsx
@@ -49,7 +49,7 @@ const temporalToTitle = (temporal: string[] | string) => {
   const [start, end] = temporal
   if (!start && !end) return null
   if (start === end) return start
-  if (!end) return `${start} ongoing`
+  if (!end) return `${start} to Present`
   if (!start) return `Up to ${end}`
 
   return `${start} to ${end}`

--- a/src/ts/component/AppliedFilters/__tests__/AppliedFilters.test.tsx
+++ b/src/ts/component/AppliedFilters/__tests__/AppliedFilters.test.tsx
@@ -178,7 +178,7 @@ describe('AppliedFilters', () => {
         }
       })
 
-      expect(screen.getByText('2020-01-01 ongoing')).toBeInTheDocument()
+      expect(screen.getByText('2020-01-01 to Present')).toBeInTheDocument()
     })
   })
 

--- a/src/ts/component/SearchResultItem/SearchResultItem.tsx
+++ b/src/ts/component/SearchResultItem/SearchResultItem.tsx
@@ -101,7 +101,7 @@ function ummTemporalToHuman(umm: object): string | null {
 
   if (!start && !end) return null
   if (start === end) return start
-  if (!end) return `${start} ongoing`
+  if (!end) return `${start} to Present`
 
   return `${start} to ${end}`
 }

--- a/src/ts/component/SearchResultItem/__tests__/SearchResultItem.test.tsx
+++ b/src/ts/component/SearchResultItem/__tests__/SearchResultItem.test.tsx
@@ -137,12 +137,12 @@ describe('DataCatalog SearchResultItem component', () => {
     expect(screen.getByText('2021-01-03')).toBeInTheDocument()
   })
 
-  test('renders forward-processing collection temporal as "ongoing"', () => {
+  test('renders forward-processing collection temporal as "to Present"', () => {
     const metadata = mockUmm()
     delete metadata.umm.TemporalExtents[0].RangeDateTimes[0].EndingDateTime
     renderMetadata(metadata)
 
-    expect(screen.getByText('2021-01-01 ongoing')).toBeInTheDocument()
+    expect(screen.getByText('2021-01-01 to Present')).toBeInTheDocument()
   })
 
   test('renders temporal with start == end as a single date', () => {


### PR DESCRIPTION
# Overview

### What is the feature?

Replacing 'ongoing' text with 'to Present'

### What is the Solution?

Updating text

### What areas of the application does this impact?

Listed temporal range

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

Visit the Data Catalog website. You may filter with the Temporal Facet by choosing a start date. You should see the following text showing the '<Date> to Present' in the filter as well as the collections returned. See screenshot. 

### Attachments
<img width="1788" height="1045" alt="Screenshot 2025-09-30 at 5 57 02 PM" src="https://github.com/user-attachments/assets/ef30a92d-5607-42c8-88cb-22dae6661195" />

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
